### PR TITLE
Use `httr2::req_perform_stream(round = "line")`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,3 +40,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
+Remotes: romainfrancois/httr2@req_perform_stream_lines

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,5 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 VignetteBuilder: knitr
-Remotes: romainfrancois/httr2@req_perform_stream_lines
+Remotes: r-lib/httr2
+

--- a/R/backend-openai-core.R
+++ b/R/backend-openai-core.R
@@ -52,7 +52,7 @@ openai_stream_ide <- function(defaults, req_body) {
           openai_stream_ide_delta(x, defaults)
           TRUE
         },
-        buffer_kb = 0.1, round = "lines"
+        buffer_kb = 0.1, round = "line"
       )
     if (!ui_current_console()) ide_paste_text("\n\n")
     ret <- ch_env$stream$response

--- a/R/backend-openai-core.R
+++ b/R/backend-openai-core.R
@@ -121,7 +121,7 @@ openai_stream_file <- function(
           openai_stream_file_delta(x, defaults, r_file_stream)
           TRUE
         },
-        buffer_kb = 0.05, round = "lines"
+        buffer_kb = 0.05, round = "line"
       )
     ret <- readRDS(r_file_stream)
     saveRDS(ret, r_file_complete)

--- a/R/backend-openai-core.R
+++ b/R/backend-openai-core.R
@@ -52,7 +52,7 @@ openai_stream_ide <- function(defaults, req_body) {
           openai_stream_ide_delta(x, defaults)
           TRUE
         },
-        buffer_kb = 0.1
+        buffer_kb = 0.1, round = "lines"
       )
     if (!ui_current_console()) ide_paste_text("\n\n")
     ret <- ch_env$stream$response
@@ -121,7 +121,7 @@ openai_stream_file <- function(
           openai_stream_file_delta(x, defaults, r_file_stream)
           TRUE
         },
-        buffer_kb = 0.05
+        buffer_kb = 0.05, round = "lines"
       )
     ret <- readRDS(r_file_stream)
     saveRDS(ret, r_file_complete)

--- a/tests/testthat/test-backend-openai-core.R
+++ b/tests/testthat/test-backend-openai-core.R
@@ -20,11 +20,13 @@ test_that("Stream parser works", {
   expect_equal(stream, msg_gpt)
 
   out <- raw %>%
+    charToRaw() %>%
     openai_stream_ide_delta(chattr_defaults(), testing = TRUE)
 
   expect_equal(out, msg_gpt)
 
   out2 <- raw %>%
+    charToRaw() %>%
     openai_stream_ide_delta(chattr_defaults(), testing = TRUE)
 
   expect_equal(out2, paste0(msg_gpt, msg_gpt))
@@ -45,7 +47,7 @@ test_that("Stream file parser works", {
 
   openai_stream_file_delta(
     defaults = chattr_defaults(),
-    x = raw,
+    x = charToRaw(raw),
     r_file_stream = out_file
   )
 

--- a/tests/testthat/test-backend-openai-core.R
+++ b/tests/testthat/test-backend-openai-core.R
@@ -20,13 +20,11 @@ test_that("Stream parser works", {
   expect_equal(stream, msg_gpt)
 
   out <- raw %>%
-    charToRaw() %>%
     openai_stream_ide_delta(chattr_defaults(), testing = TRUE)
 
   expect_equal(out, msg_gpt)
 
   out2 <- raw %>%
-    charToRaw() %>%
     openai_stream_ide_delta(chattr_defaults(), testing = TRUE)
 
   expect_equal(out2, paste0(msg_gpt, msg_gpt))
@@ -47,7 +45,7 @@ test_that("Stream file parser works", {
 
   openai_stream_file_delta(
     defaults = chattr_defaults(),
-    x = charToRaw(raw),
+    x = raw,
     r_file_stream = out_file
   )
 


### PR DESCRIPTION
closes #63 

This uses `httr2::req_perform_stream_lines()` from https://github.com/r-lib/httr2/pull/437 so that the data from open ai is dealt with line by line instead of some number of bytes. 

This PR is meant more as a conversation aid for the `httr2` PR. 

If `httr2` actually had `httr2::req_perform_stream_lines()` or something serving the same purpose: consume stream line by line, then I believe some of the logic around `ch_env$stream$raw` could be improved, because we would know that we get complete `data: {json}` lines, and so `openai_stream_parse()` etc ... could be simplified. 

Compared to #64 which has to do tricks with the bytes buffer, this feels much nicer. 

So now we can stream the `golem` poem, cc @ColinFay 🫣

https://github.com/mlverse/chattr/assets/2625526/625062a0-2604-4874-9207-f23a2c0807c2

