### PR TITLE
Fix for dev httr2

### DIFF
--- a/tests/testthat/test-backend-databricks.R
+++ b/tests/testthat/test-backend-databricks.R
@@ -21,7 +21,7 @@ test_that("Submit method works", {
 test_that("Completion function works", {
   withr::with_envvar(
     new = c(
-      "DATABRICKS_HOST" = "test",
+      "DATABRICKS_HOST" = "http://test",
       "DATABRICKS_TOKEN" = "test"
     ),
     {


### PR DESCRIPTION
httr2 has switched to a more aggressive URL parser which now throws an error, so I've made the minimal fix to get your tests passing again The proposed code should work with both old and new httr2, so you can submit to CRAN now, if you want. I am planning to submit httr2 to CRAN on Jan 17, so you'll have to submit ~2 weeks after this date. \